### PR TITLE
Added the ability to create UDPBurst measurements through the AppEngine backend

### DIFF
--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -34,7 +34,9 @@ MEASUREMENT_TYPES = [('ping', 'ping'),
                      ('dns_lookup', 'DNS lookup'),
                      ('traceroute', 'traceroute'),
                      ('http', 'HTTP get'),
-                     ('ndt', 'NDT measurement')]
+                     ('ndt', 'NDT measurement'),
+                     ('UDPBurst Up', 'UDPBurst Up'),
+                     ('UDPBurst Down', 'UDPBurst Down')]
 
 
 class Measurement(webapp.RequestHandler):

--- a/server/gspeedometer/controllers/measurement.py
+++ b/server/gspeedometer/controllers/measurement.py
@@ -35,8 +35,7 @@ MEASUREMENT_TYPES = [('ping', 'ping'),
                      ('traceroute', 'traceroute'),
                      ('http', 'HTTP get'),
                      ('ndt', 'NDT measurement'),
-                     ('UDPBurst Up', 'UDPBurst Up'),
-                     ('UDPBurst Down', 'UDPBurst Down')]
+                     ('udp_burst', 'UDP Burst')]
 
 
 class Measurement(webapp.RequestHandler):

--- a/server/gspeedometer/controllers/schedule.py
+++ b/server/gspeedometer/controllers/schedule.py
@@ -38,6 +38,7 @@ class AddToScheduleForm(forms.Form):
   param2 = forms.CharField(required=False)
   param3 = forms.CharField(required=False)
   param4 = forms.CharField(required=False)
+  param5 = forms.CharField(required=False)
   count = forms.IntegerField(required=False, initial=-1,
                              min_value=-1, max_value=1000)
   interval = forms.IntegerField(required=True, label='Interval (sec)',
@@ -66,6 +67,7 @@ class Schedule(webapp.RequestHandler):
         param2 = add_to_schedule_form.cleaned_data['param2']
         param3 = add_to_schedule_form.cleaned_data['param3']
         param4 = add_to_schedule_form.cleaned_data['param4']
+        param5 = add_to_schedule_form.cleaned_data['param5']
         tag = add_to_schedule_form.cleaned_data['tag']
         thefilter = add_to_schedule_form.cleaned_data['filter']
         count = add_to_schedule_form.cleaned_data['count'] or -1
@@ -100,18 +102,12 @@ class Schedule(webapp.RequestHandler):
         elif task.type == 'dns_lookup':
           task.mparam_target = param1
           task.mparam_server = param2
-        elif task.type == 'UDPBurstUp':
+        elif task.type == 'udp_burst':
           task.mparam_target = param1
           task.mparam_packet_size_byte = param2
           task.mparam_packet_burst = param3
           task.mparam_dst_port = param4
-          task.mparam_direction = "up"
-        elif task.type == 'UDPBurstDown':
-          task.mparam_target = param1
-          task.mparam_packet_size_byte = param2
-          task.mparam_packet_burst = param3
-          task.mparam_dst_port = param4
-          task.mparam_direction = "down"
+          task.mparam_direction = param5
         task.put()
 
     schedule = model.Task.all()

--- a/server/gspeedometer/controllers/schedule.py
+++ b/server/gspeedometer/controllers/schedule.py
@@ -37,6 +37,7 @@ class AddToScheduleForm(forms.Form):
   param1 = forms.CharField(required=False)
   param2 = forms.CharField(required=False)
   param3 = forms.CharField(required=False)
+  param4 = forms.CharField(required=False)
   count = forms.IntegerField(required=False, initial=-1,
                              min_value=-1, max_value=1000)
   interval = forms.IntegerField(required=True, label='Interval (sec)',
@@ -64,6 +65,7 @@ class Schedule(webapp.RequestHandler):
         param1 = add_to_schedule_form.cleaned_data['param1']
         param2 = add_to_schedule_form.cleaned_data['param2']
         param3 = add_to_schedule_form.cleaned_data['param3']
+        param4 = add_to_schedule_form.cleaned_data['param4']
         tag = add_to_schedule_form.cleaned_data['tag']
         thefilter = add_to_schedule_form.cleaned_data['filter']
         count = add_to_schedule_form.cleaned_data['count'] or -1
@@ -98,6 +100,18 @@ class Schedule(webapp.RequestHandler):
         elif task.type == 'dns_lookup':
           task.mparam_target = param1
           task.mparam_server = param2
+        elif task.type == 'UDPBurstUp':
+          task.mparam_target = param1
+          task.mparam_packet_size_byte = param2
+          task.mparam_packet_burst = param3
+          task.mparam_dst_port = param4
+          task.mparam_direction = "up"
+        elif task.type == 'UDPBurstDown':
+          task.mparam_target = param1
+          task.mparam_packet_size_byte = param2
+          task.mparam_packet_burst = param3
+          task.mparam_dst_port = param4
+          task.mparam_direction = "down"
         task.put()
 
     schedule = model.Task.all()


### PR DESCRIPTION
I added two new measurement types "UDPBurst Up" and "UDPBurst Down" in the set of MEASUREMENT_TYPES. 

Also added a fourth parameter in the "schedule/add" page which is necessary to store the port parameter for UDPBurst measurements. 

Finally, for each of the two new measurement types I translate the generics param1,2,3,4 to the parameters that the UDPBurst class is expecting. 

Tested using local AppEngine and works OK
