### PR TITLE
Better statistics tracking in the Speedometer app

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.google.wireless.speed.speedometer"
-  android:versionCode="23"
-  android:versionName="1.4.4">
+  android:versionCode="24"
+  android:versionName="1.4.5">
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.GET_ACCOUNTS" />
   <uses-permission android:name="android.permission.USE_CREDENTIALS" />

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.google.wireless.speed.speedometer"
-  android:versionCode="24"
-  android:versionName="1.4.5">
+  android:versionCode="25"
+  android:versionName="1.4.6">
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.GET_ACCOUNTS" />
   <uses-permission android:name="android.permission.USE_CREDENTIALS" />

--- a/android/res/layout/main.xml
+++ b/android/res/layout/main.xml
@@ -25,6 +25,14 @@
         android:background="@color/lightGray"
         android:textColor="@color/white"
         android:id="@+id/systemStatusBar"/>
+      <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/largeTextSize"
+        android:gravity="center_horizontal"
+        android:background="@color/lightGray"
+        android:textColor="@color/white"
+        android:id="@+id/systemStatsBar"/>
       <FrameLayout 
         android:id="@android:id/tabcontent"
         android:layout_width="match_parent" 

--- a/android/src/com/google/wireless/speed/speedometer/BatteryCapPowerManager.java
+++ b/android/src/com/google/wireless/speed/speedometer/BatteryCapPowerManager.java
@@ -19,7 +19,6 @@ import com.google.wireless.speed.speedometer.util.PhoneUtils;
 
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
 
 import java.util.Calendar;
 import java.util.concurrent.Callable;
@@ -84,7 +83,7 @@ public class BatteryCapPowerManager {
     }
     
     private void broadcastMeasurementStart() {
-      Log.i(SpeedometerApp.TAG, "Starting PowerAwareTask " + realTask);
+      Logger.i("Starting PowerAwareTask " + realTask);
       Intent intent = new Intent();
       intent.setAction(UpdateIntent.SYSTEM_STATUS_UPDATE_ACTION);
       intent.putExtra(UpdateIntent.STATUS_MSG_PAYLOAD, "Running " + realTask.getDescriptor());
@@ -93,7 +92,7 @@ public class BatteryCapPowerManager {
     }
     
     private void broadcastMeasurementEnd(MeasurementResult result, MeasurementError error) {
-      Log.i(SpeedometerApp.TAG, "Ending PowerAwareTask " + realTask);
+      Logger.i("Ending PowerAwareTask " + realTask);
       // Only broadcast information about measurements if they are true errors.
       if (!(error instanceof MeasurementSkippedException)) {
         Intent intent = new Intent();
@@ -124,31 +123,31 @@ public class BatteryCapPowerManager {
       try {
         PhoneUtils.getPhoneUtils().acquireWakeLock();
         if (scheduler.isPauseRequested()) {
-          Log.i(SpeedometerApp.TAG, "Skipping measurement - scheduler paused");
+          Logger.i("Skipping measurement - scheduler paused");
           throw new MeasurementSkippedException("Scheduler paused");
         }
         if (!pManager.canScheduleExperiment()) {
-          Log.i(SpeedometerApp.TAG, "Skipping measurement - low battery");
+          Logger.i("Skipping measurement - low battery");
           throw new MeasurementSkippedException("Not enough battery power");
         }
         if (PhoneUtils.getPhoneUtils().getNetwork() == PhoneUtils.NETWORK_WIFI) {
-          Log.i(SpeedometerApp.TAG, "Skipping measurement - on wifi");
+          Logger.i("Skipping measurement - on wifi");
           throw new MeasurementSkippedException("Connected via WiFi");
         }
         scheduler.setCurrentTask(realTask);
         broadcastMeasurementStart();
         try {
-          Log.i(SpeedometerApp.TAG, "Calling PowerAwareTask " + realTask);
+          Logger.i("Calling PowerAwareTask " + realTask);
           result = realTask.call(); 
-          Log.i(SpeedometerApp.TAG, "Got result " + result);
+          Logger.i("Got result " + result);
           broadcastMeasurementEnd(result, null);
           return result;
         } catch (MeasurementError e) {
-          Log.e(SpeedometerApp.TAG, "Got MeasurementError running task", e);
+          Logger.e("Got MeasurementError running task", e);
           broadcastMeasurementEnd(null, e);
           throw e;
         } catch (Exception e) {
-          Log.e(SpeedometerApp.TAG, "Got exception running task", e);
+          Logger.e("Got exception running task", e);
           MeasurementError err = new MeasurementError("Got exception running task", e);
           broadcastMeasurementEnd(null, err);
           throw err;

--- a/android/src/com/google/wireless/speed/speedometer/BatteryCapPowerManager.java
+++ b/android/src/com/google/wireless/speed/speedometer/BatteryCapPowerManager.java
@@ -109,7 +109,7 @@ public class BatteryCapPowerManager {
           if (error != null) {
             errorString += "\n\n" + error.toString();
           } 
-          intent.putExtra(UpdateIntent.STRING_PAYLOAD, errorString);
+          intent.putExtra(UpdateIntent.ERROR_STRING_PAYLOAD, errorString);
         }
         scheduler.sendBroadcast(intent);
       }

--- a/android/src/com/google/wireless/speed/speedometer/Config.java
+++ b/android/src/com/google/wireless/speed/speedometer/Config.java
@@ -83,6 +83,8 @@ public interface Config {
   public static final String PREF_KEY_STATUS_BAR = "PREF_KEY_STATUS_BAR";
   public static final String PREF_KEY_SYSTEM_RESULTS = "PREF_KEY_SYSTEM_RESULTS";
   public static final String PREF_KEY_USER_RESULTS = "PREF_KEY_USER_RESULTS";
+  public static final String PREF_KEY_COMPLETED_MEASUREMENTS = "PREF_KEY_COMPLETED_MEASUREMENTS";
+  public static final String PREF_KEY_FAILED_MEASUREMENTS = "PREF_KEY_FAILED_MEASUREMENTS";
   
   /** Constants for the splash screen */
   public static final long SPLASH_SCREEN_DURATION_MSEC = 1500;

--- a/android/src/com/google/wireless/speed/speedometer/Logger.java
+++ b/android/src/com/google/wireless/speed/speedometer/Logger.java
@@ -1,0 +1,77 @@
+// Copyright 2011 Google Inc. All Rights Reserved.
+
+package com.google.wireless.speed.speedometer;
+
+import android.util.Log;
+
+/**
+ * Wrapper for logging operations which can be disabled by setting LOGGING_ENABLED.
+ * 
+ * @author mdw@google.com (Matt Welsh)
+ *
+ */
+public class Logger {
+  private final static boolean LOGGING_ENABLED = false;
+  private final static String TAG = "Speedometer";
+  
+  public static void d(String msg) {
+    if (LOGGING_ENABLED) {
+      Log.d(TAG, msg);
+    }
+  }
+  
+  public static void d(String msg, Throwable t) {
+    if (LOGGING_ENABLED) {
+      Log.d(TAG, msg, t);
+    }
+  }
+  
+  public static void e(String msg) {
+    if (LOGGING_ENABLED) {
+      Log.e(TAG, msg);
+    }
+  }
+  
+  public static void e(String msg, Throwable t) {
+    if (LOGGING_ENABLED) {
+      Log.e(TAG, msg, t);
+    }
+  }
+  
+  public static void i(String msg) {
+    if (LOGGING_ENABLED) {
+      Log.i(TAG, msg);
+    }
+  }
+  
+  public static void i(String msg, Throwable t) {
+    if (LOGGING_ENABLED) {
+      Log.i(TAG, msg, t);
+    }
+  }
+  
+  public static void v(String msg) {
+    if (LOGGING_ENABLED) {
+      Log.v(TAG, msg);
+    }
+  }
+  
+  public static void v(String msg, Throwable t) {
+    if (LOGGING_ENABLED) {
+      Log.v(TAG, msg, t);
+    }
+  }
+  
+  public static void w(String msg) {
+    if (LOGGING_ENABLED) {
+      Log.w(TAG, msg);
+    }
+  }
+  
+  public static void w(String msg, Throwable t) {
+    if (LOGGING_ENABLED) {
+      Log.w(TAG, msg, t);
+    }
+  }
+
+}

--- a/android/src/com/google/wireless/speed/speedometer/MeasurementCreationActivity.java
+++ b/android/src/com/google/wireless/speed/speedometer/MeasurementCreationActivity.java
@@ -260,7 +260,7 @@ public class MeasurementCreationActivity extends Activity {
           }
         }
       } catch (Exception e) {
-        Log.e(SpeedometerApp.TAG, "Exception when creating user measurements", e);
+        Logger.e("Exception when creating user measurements", e);
         Toast.makeText(MeasurementCreationActivity.this, R.string.invalidUserMeasurementInputToast,
             Toast.LENGTH_LONG).show();
       }

--- a/android/src/com/google/wireless/speed/speedometer/MeasurementResult.java
+++ b/android/src/com/google/wireless/speed/speedometer/MeasurementResult.java
@@ -100,11 +100,11 @@ public class MeasurementResult {
       }
       return builder.toString();
     } catch (NumberFormatException e) {
-      Log.e(SpeedometerApp.TAG, "Exception occurs during constructing result string for user", e);
+      Logger.e("Exception occurs during constructing result string for user", e);
     } catch (ClassCastException e) {
-      Log.e(SpeedometerApp.TAG, "Exception occurs during constructing result string for user", e);
+      Logger.e("Exception occurs during constructing result string for user", e);
     } catch (Exception e) {
-      Log.e(SpeedometerApp.TAG, "Exception occurs during constructing result string for user", e);
+      Logger.e("Exception occurs during constructing result string for user", e);
     }
     return "Measurement has failed";
   }

--- a/android/src/com/google/wireless/speed/speedometer/MeasurementScheduleConsoleActivity.java
+++ b/android/src/com/google/wireless/speed/speedometer/MeasurementScheduleConsoleActivity.java
@@ -97,7 +97,7 @@ public class MeasurementScheduleConsoleActivity extends Activity {
     this.receiver = new BroadcastReceiver() {
       @Override
       public void onReceive(Context context, Intent intent) {
-        Log.d(SpeedometerApp.TAG, "MeasurementConsole got intent");
+        Logger.d("MeasurementConsole got intent");
         /* The content of the console is maintained by the scheduler. We simply hook up the 
          * view with the content here. */
         updateConsole();
@@ -153,7 +153,7 @@ public class MeasurementScheduleConsoleActivity extends Activity {
   }
   
   private void updateLastCheckinTime() {
-    Log.i(SpeedometerApp.TAG, "updateLastCheckinTime() called");
+    Logger.i("updateLastCheckinTime() called");
     scheduler = parent.getScheduler();
     if (scheduler != null) {
       Date lastCheckin = scheduler.getLastCheckinTime();
@@ -166,7 +166,7 @@ public class MeasurementScheduleConsoleActivity extends Activity {
   }
   
   private void updateConsole() {
-    Log.i(SpeedometerApp.TAG, "updateConsole() called");
+    Logger.i("updateConsole() called");
     scheduler = parent.getScheduler();
     if (scheduler != null) {
       AbstractCollection<MeasurementTask> tasks = scheduler.getTaskQueue();
@@ -182,7 +182,7 @@ public class MeasurementScheduleConsoleActivity extends Activity {
   }
   
   private void doCheckin() {
-    Log.i(SpeedometerApp.TAG, "doCheckin() called");
+    Logger.i("doCheckin() called");
     scheduler = parent.getScheduler();
     if (scheduler != null) {
       lastCheckinTimeText.setText("Checking in...");

--- a/android/src/com/google/wireless/speed/speedometer/MeasurementScheduler.java
+++ b/android/src/com/google/wireless/speed/speedometer/MeasurementScheduler.java
@@ -171,13 +171,13 @@ public class MeasurementScheduler extends Service {
           updateFromPreference();
         } else if (intent.getAction().equals(UpdateIntent.CHECKIN_ACTION) ||
               intent.getAction().equals(UpdateIntent.CHECKIN_RETRY_ACTION)) {
-          Log.d(SpeedometerApp.TAG, "Checkin intent received");
+          Logger.d("Checkin intent received");
           handleCheckin(false);
         } else if (intent.getAction().equals(UpdateIntent.MEASUREMENT_ACTION)) {
-          Log.d(SpeedometerApp.TAG, "MeasurementIntent intent received");
+          Logger.d("MeasurementIntent intent received");
           handleMeasurement();
         } else if (intent.getAction().equals(UpdateIntent.MEASUREMENT_PROGRESS_UPDATE_ACTION)) {
-          Log.d(SpeedometerApp.TAG, "MeasurementIntent update intent received");
+          Logger.d("MeasurementIntent update intent received");
           if (intent.getIntExtra(UpdateIntent.PROGRESS_PAYLOAD, Config.INVALID_PROGRESS) == 
               Config.MEASUREMENT_END_PROGRESS) {
             completedMeasurementCnt++;
@@ -250,7 +250,7 @@ public class MeasurementScheduler extends Service {
       if (task != null && task.timeFromExecution() <= 0) {
         taskQueue.poll();
         Future<MeasurementResult> future;
-        Log.i(SpeedometerApp.TAG, "Processing task " + task.toString());
+        Logger.i("Processing task " + task.toString());
         // Run the head task using the executor
         if (task.getDescription().priority == MeasurementTask.USER_PRIORITY) {
           sendStringMsg("Scheduling user task:\n" + task);
@@ -292,11 +292,11 @@ public class MeasurementScheduler extends Service {
       }
     } catch (IllegalArgumentException e) {
       // Task creation in clone can create this exception
-      Log.e(SpeedometerApp.TAG, "Exception when cloning task");
+      Logger.e("Exception when cloning task");
       sendStringMsg("Exception when cloning task: " + e);
     } catch (Exception e) {
       // We don't want any unexpected exception to crash the process
-      Log.e(SpeedometerApp.TAG, "Exception when handling measurements", e);
+      Logger.e("Exception when handling measurements", e);
       sendStringMsg("Exception running task: " + e);
     }
   }
@@ -341,7 +341,7 @@ public class MeasurementScheduler extends Service {
   @Override 
   public int onStartCommand(Intent intent, int flags, int startId)  {
     // Start up the thread running the service. Using one single thread for all requests
-    Log.i(SpeedometerApp.TAG, "starting scheduler");
+    Logger.i("starting scheduler");
     sendStringMsg("Scheduler starting");
     if (!isSchedulerStarted) {
       updateFromPreference();
@@ -376,7 +376,7 @@ public class MeasurementScheduler extends Service {
         System.currentTimeMillis() + Config.PAUSE_BETWEEN_CHECKIN_CHANGE_MSEC, 
         checkinIntervalSec * 1000, checkinIntentSender);
     
-    Log.i(SpeedometerApp.TAG, "Setting checkin interval to " + interval + " seconds");
+    Logger.i("Setting checkin interval to " + interval + " seconds");
   }
   
   /** Returns the checkin interval of the scheduler in seconds */
@@ -478,10 +478,10 @@ public class MeasurementScheduler extends Service {
       //Automatically notifies the scheduler waiting on taskQueue.take()
       return this.taskQueue.add(task);
     } catch (NullPointerException e) {
-      Log.e(SpeedometerApp.TAG, "The task to be added is null");
+      Logger.e("The task to be added is null");
       return false;
     } catch (ClassCastException e) {
-      Log.e(SpeedometerApp.TAG, "cannot compare this task against existing ones");
+      Logger.e("cannot compare this task against existing ones");
       return false;
     }
   }
@@ -525,11 +525,11 @@ public class MeasurementScheduler extends Service {
       
       updateStatus();
       
-      Log.i(SpeedometerApp.TAG, "Preference set from SharedPreference: " + 
+      Logger.i("Preference set from SharedPreference: " + 
           "checkinInterval=" + checkinIntervalSec +
           ", minBatThres= " + powerManager.getBatteryThresh());
     } catch (ClassCastException e) {
-      Log.e(SpeedometerApp.TAG, "exception when casting preference values", e);
+      Logger.e("exception when casting preference values", e);
     }
   }
   
@@ -554,7 +554,7 @@ public class MeasurementScheduler extends Service {
     this.checkin.shutDown();
 
     this.unregisterReceiver(broadcastReceiver);
-    Log.i(SpeedometerApp.TAG, "canceling pending intents");
+    Logger.i("canceling pending intents");
 
     if (checkinIntentSender != null) {
       checkinIntentSender.cancel();
@@ -576,7 +576,7 @@ public class MeasurementScheduler extends Service {
     saveConsoleContent(userResults, Config.PREF_KEY_USER_RESULTS);
     saveConsoleContent(systemConsole, Config.PREF_KEY_SYSTEM_CONSOLE);
     
-    Log.i(SpeedometerApp.TAG, "Shut down all executors and stopping service");
+    Logger.i("Shut down all executors and stopping service");
   }
   
   private void resetCheckin() {
@@ -587,14 +587,14 @@ public class MeasurementScheduler extends Service {
   }
   
   private void getTasksFromServer() throws IOException {
-    Log.i(SpeedometerApp.TAG, "Downloading tasks from the server");
+    Logger.i("Downloading tasks from the server");
     checkin.getCookie();
     List<MeasurementTask> tasksFromServer = checkin.checkin();
     // The new task schedule overrides the old one
     removeAllUnscheduledTasks();
 
     for (MeasurementTask task : tasksFromServer) {
-      Log.i(SpeedometerApp.TAG, "added task: " + task.toString());
+      Logger.i("added task: " + task.toString());
       this.submitTask(task);
     }
   }
@@ -618,25 +618,25 @@ public class MeasurementScheduler extends Service {
                   result = future.get();
                   finishedTasks.add(result);
                 } else {
-                  Log.e(SpeedometerApp.TAG, "Task execution was canceled");
+                  Logger.e("Task execution was canceled");
                   finishedTasks.add(this.getFailureResult(task,
                       new CancellationException("Task cancelled")));
                 }
               } catch (InterruptedException e) {
-                Log.e(SpeedometerApp.TAG, "Task execution interrupted", e);
+                Logger.e("Task execution interrupted", e);
               } catch (ExecutionException e) {
                 if (e.getCause() instanceof MeasurementSkippedException) {
                   // Don't do anything with this - no need to report skipped measurements
                   sendStringMsg("Task skipped - " + e.getCause().toString() + "\n" + task);
-                  Log.i(SpeedometerApp.TAG, "Task skipped", e.getCause());
+                  Logger.i("Task skipped", e.getCause());
                 } else {
                   // Log the error
                   sendStringMsg("Task failed - " + e.getCause().toString() + "\n" + task);
-                  Log.e(SpeedometerApp.TAG, "Task execution failed", e.getCause());
+                  Logger.e("Task execution failed", e.getCause());
                   finishedTasks.add(this.getFailureResult(task, e.getCause()));
                 }
               } catch (CancellationException e) {
-                Log.e(SpeedometerApp.TAG, "Task cancelled", e);
+                Logger.e("Task cancelled", e);
               }
             } else if (task.isPassedDeadline()) {
               /* If a task has reached its deadline but has not been run, 
@@ -663,7 +663,7 @@ public class MeasurementScheduler extends Service {
          * ConcurrentModificationException. Since we have synchronized all changes to pendingTasks
          * this should not happen. 
          */
-        Log.e(SpeedometerApp.TAG, "Pending tasks is changed during measurement upload");
+        Logger.e("Pending tasks is changed during measurement upload");
       }
     }
     
@@ -671,18 +671,18 @@ public class MeasurementScheduler extends Service {
       try {
         this.checkin.uploadMeasurementResult(finishedTasks);
       } catch (IOException e) {
-        Log.e(SpeedometerApp.TAG, "Error when uploading message");
+        Logger.e("Error when uploading message");
       }
     }
     
-    Log.i(SpeedometerApp.TAG, "A total of " + finishedTasks.size() + " uploaded");
-    Log.i(SpeedometerApp.TAG, "A total of " + this.pendingTasks.size() + " is in pendingTasks");
+    Logger.i("A total of " + finishedTasks.size() + " uploaded");
+    Logger.i("A total of " + this.pendingTasks.size() + " is in pendingTasks");
   }
   
   private class CheckinTask implements Runnable {
     @Override
     public void run() {
-      Log.i(SpeedometerApp.TAG, "checking Speedometer service for new tasks");
+      Logger.i("checking Speedometer service for new tasks");
       lastCheckinTime = Calendar.getInstance();
       try {
         uploadResults();
@@ -696,13 +696,13 @@ public class MeasurementScheduler extends Service {
          * Executor stops all subsequent execution of a periodic task if a raised
          * exception is uncaught. We catch all undeclared exceptions here
          */
-        Log.e(SpeedometerApp.TAG, "Unexpected exceptions caught", e);
+        Logger.e("Unexpected exceptions caught", e);
         if (checkinRetryCnt > Config.MAX_CHECKIN_RETRY_COUNT) {
           /* If we have retried more than MAX_CHECKIN_RETRY_COUNT times upon a checkin failure, 
            * we will stop retrying and wait until the next checkin period*/
           resetCheckin();
         } else if (checkinRetryIntervalSec < checkinIntervalSec) {
-          Log.i(SpeedometerApp.TAG, "Retrying checkin in " + checkinRetryIntervalSec + " seconds");
+          Logger.i("Retrying checkin in " + checkinRetryIntervalSec + " seconds");
           /* Use checkinRetryIntentSender so that the periodic checkin schedule will
            * remain intact
            */

--- a/android/src/com/google/wireless/speed/speedometer/ResultsConsoleActivity.java
+++ b/android/src/com/google/wireless/speed/speedometer/ResultsConsoleActivity.java
@@ -129,7 +129,7 @@ public class ResultsConsoleActivity extends Activity {
    *  Upgrades the progress bar in the UI.
    *  */
   private void upgradeProgress(int progress, int max) {
-    Log.i(SpeedometerApp.TAG, "Progress is " + progress);
+    Logger.i("Progress is " + progress);
     if (progress >= 0 && progress <= max) {
       progressBar.setProgress(progress);
       this.progressBar.setVisibility(View.VISIBLE);

--- a/android/src/com/google/wireless/speed/speedometer/SpeedometerApp.java
+++ b/android/src/com/google/wireless/speed/speedometer/SpeedometerApp.java
@@ -49,13 +49,14 @@ public class SpeedometerApp extends TabActivity {
   public static final String TAG = "Speedometer";
   
   private boolean consentDialogShown = false;
+  
   private static final int DIALOG_CONSENT = 0;
   private MeasurementScheduler scheduler;
   private TabHost tabHost;
   private boolean isBound = false;
   private boolean isBindingToService = false;
   private BroadcastReceiver receiver;
-  TextView statusBar;
+  TextView statusBar, statsBar;
   
   @Override
   protected void onSaveInstanceState(Bundle savedInstanceState) {
@@ -193,7 +194,6 @@ public class SpeedometerApp extends TabActivity {
     TabHost.TabSpec spec;  // Resusable TabSpec for each tab
     Intent intent;  // Reusable Intent for each tab
 
-    
     // Do the same for the other tabs
     intent = new Intent().setClass(this, MeasurementCreationActivity.class);
     spec = tabHost.newTabSpec(MeasurementCreationActivity.TAB_TAG).setIndicator(
@@ -214,6 +214,7 @@ public class SpeedometerApp extends TabActivity {
     tabHost.setCurrentTabByTag(MeasurementCreationActivity.TAB_TAG);
     
     statusBar = (TextView) findViewById(R.id.systemStatusBar);
+    statsBar = (TextView) findViewById(R.id.systemStatsBar);
     
     // We only need one instance of the scheduler thread
     intent = new Intent(this, MeasurementScheduler.class);
@@ -223,11 +224,17 @@ public class SpeedometerApp extends TabActivity {
       @Override
       // All onXyz() callbacks are single threaded
       public void onReceive(Context context, Intent intent) {
+        // Update the status bar on SYSTEM_STATUS_UPDATE_ACTION intents
         String statusMsg = intent.getStringExtra(UpdateIntent.STATUS_MSG_PAYLOAD);
         if (statusMsg != null) {
           updateStatusBar(statusMsg);
         } else if (scheduler != null) {
           initializeStatusBar();
+        }
+        
+        String statsMsg = intent.getStringExtra(UpdateIntent.STATS_MSG_PAYLOAD);
+        if (statsMsg != null) {
+          updateStatsBar(statsMsg);
         }
       }
     };
@@ -267,6 +274,12 @@ public class SpeedometerApp extends TabActivity {
   private void updateStatusBar(String statusMsg) {
     if (statusMsg != null) {
       statusBar.setText(statusMsg);
+    }
+  }
+  
+  private void updateStatsBar(String statsMsg) {
+    if (statsMsg != null) {
+      statsBar.setText(statsMsg);
     }
   }
   

--- a/android/src/com/google/wireless/speed/speedometer/SpeedometerApp.java
+++ b/android/src/com/google/wireless/speed/speedometer/SpeedometerApp.java
@@ -143,7 +143,7 @@ public class SpeedometerApp extends TabActivity {
         }
         return true;
       case R.id.menuQuit:
-        Log.i(TAG, "User requests exit. Quiting the app");
+        Logger.i("User requests exit. Quiting the app");
         quitApp();
         return true;
       case R.id.menuSettings:

--- a/android/src/com/google/wireless/speed/speedometer/SpeedometerPreferenceActivity.java
+++ b/android/src/com/google/wireless/speed/speedometer/SpeedometerPreferenceActivity.java
@@ -43,7 +43,7 @@ public class SpeedometerPreferenceActivity extends PreferenceActivity {
     
     /* This should never occur. */
     if (intervalPref == null || batteryPref == null) {
-      Log.w(SpeedometerApp.TAG, "Cannot find some of the preferences");
+      Logger.w("Cannot find some of the preferences");
       Toast.makeText(SpeedometerPreferenceActivity.this, 
         getString(R.string.menuInitializationExceptionToast), Toast.LENGTH_LONG).show();
       return;
@@ -63,10 +63,10 @@ public class SpeedometerPreferenceActivity extends PreferenceActivity {
             }
             return true;
           } catch (ClassCastException e) {
-            Log.e(SpeedometerApp.TAG, "Cannot cast checkin interval preference value to Integer");
+            Logger.e("Cannot cast checkin interval preference value to Integer");
             return false;
           } catch (NumberFormatException e) {
-            Log.e(SpeedometerApp.TAG, "Cannot cast checkin interval preference value to Integer");
+            Logger.e("Cannot cast checkin interval preference value to Integer");
             return false;
           }
         } else if (prefKey.compareTo(getString(R.string.batteryMinThresPrefKey)) == 0) {
@@ -79,10 +79,10 @@ public class SpeedometerPreferenceActivity extends PreferenceActivity {
             }
             return true;
           } catch (ClassCastException e) {
-            Log.e(SpeedometerApp.TAG, "Cannot cast battery preference value to Integer");
+            Logger.e("Cannot cast battery preference value to Integer");
             return false;
           } catch (NumberFormatException e) {
-            Log.e(SpeedometerApp.TAG, "Cannot cast battery preference value to Integer");
+            Logger.e("Cannot cast battery preference value to Integer");
             return false;
           }
         }

--- a/android/src/com/google/wireless/speed/speedometer/UpdateIntent.java
+++ b/android/src/com/google/wireless/speed/speedometer/UpdateIntent.java
@@ -21,19 +21,21 @@ import android.content.Intent;
 import java.security.InvalidParameterException;
 
 /**
- * A repackage Intent class that include Speedometer specific information 
+ * A repackaged Intent class that includes Speedometer-specific information. 
  * @author wenjiezeng@google.com (Steve Zeng)
  *
  */
 public class UpdateIntent extends Intent {
   
-  // Different types of payload this intent can carry
+  // Different types of payloads that this intent can carry:
   public static final String STRING_PAYLOAD = "STRING_PAYLOAD";
+  public static final String ERROR_STRING_PAYLOAD = "ERROR_STRING_PAYLOAD";
   public static final String PROGRESS_PAYLOAD = "PROGRESS_PAYLOAD";
   public static final String STATUS_MSG_PAYLOAD = "STATUS_MSG_PAYLOAD";
+  public static final String STATS_MSG_PAYLOAD = "STATS_MSG_PAYLOAD";
   public static final String TASK_PRIORITY_PAYLOAD = "TASK_PRIORITY_PAYLOAD";
   
-  // Different types of actions that this intent can represent
+  // Different types of actions that this intent can represent:
   private static final String PACKAGE_PREFIX = UpdateIntent.class.getPackage().getName();
   public static final String MSG_ACTION = PACKAGE_PREFIX + ".MSG_ACTION";
   public static final String PREFERENCE_ACTION = PACKAGE_PREFIX + ".PREFERENCE_ACTION";

--- a/android/src/com/google/wireless/speed/speedometer/WatchdogBootReceiver.java
+++ b/android/src/com/google/wireless/speed/speedometer/WatchdogBootReceiver.java
@@ -32,13 +32,13 @@ public class WatchdogBootReceiver extends BroadcastReceiver {
 
   @Override
   public final void onReceive(Context context, Intent intent) {
-    Log.i(SpeedometerApp.TAG, "Boot intent received.");
+    Logger.i("Boot intent received.");
     Intent serviceIntent = new Intent(context, MeasurementScheduler.class);
     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
     
     if (prefs.getBoolean(context.getString(R.string.startOnBootPrefKey),
         Config.DEFAULT_START_ON_BOOT)) {
-      Log.i(SpeedometerApp.TAG, "Starting MeasurementScheduler from watch dog");
+      Logger.i("Starting MeasurementScheduler from watch dog");
       context.startService(serviceIntent);
     }
   }

--- a/android/src/com/google/wireless/speed/speedometer/measurements/DnsLookupTask.java
+++ b/android/src/com/google/wireless/speed/speedometer/measurements/DnsLookupTask.java
@@ -15,6 +15,7 @@
 package com.google.wireless.speed.speedometer.measurements;
 
 import com.google.wireless.speed.speedometer.Config;
+import com.google.wireless.speed.speedometer.Logger;
 import com.google.wireless.speed.speedometer.MeasurementDesc;
 import com.google.wireless.speed.speedometer.MeasurementError;
 import com.google.wireless.speed.speedometer.MeasurementResult;
@@ -109,7 +110,7 @@ public class DnsLookupTask extends MeasurementTask {
     for (int i = 0; i < Config.DEFAULT_DNS_COUNT_PER_MEASUREMENT; i++) {
       try {
         DnsLookupDesc taskDesc = (DnsLookupDesc) this.measurementDesc;
-        Log.i(SpeedometerApp.TAG, "Running DNS Lookup for target " + taskDesc.target);
+        Logger.i("Running DNS Lookup for target " + taskDesc.target);
         Date startTime = new Date();
         t1 = System.currentTimeMillis();
         InetAddress inet = InetAddress.getByName(taskDesc.target);
@@ -126,7 +127,7 @@ public class DnsLookupTask extends MeasurementTask {
     }
     
     if (resultInet != null) {
-      Log.i(SpeedometerApp.TAG, "Successfully resolved target address");
+      Logger.i("Successfully resolved target address");
       PhoneUtils phoneUtils = PhoneUtils.getPhoneUtils();
       MeasurementResult result = new MeasurementResult(phoneUtils.getDeviceInfo().deviceId,
           phoneUtils.getDeviceProperty(), DnsLookupTask.TYPE, System.currentTimeMillis() * 1000,
@@ -134,7 +135,7 @@ public class DnsLookupTask extends MeasurementTask {
       result.addResult("address", resultInet.getHostAddress());
       result.addResult("real_hostname", resultInet.getCanonicalHostName());
       result.addResult("time_ms", totalTime / successCnt);
-      Log.i(SpeedometerApp.TAG, MeasurementJsonConvertor.toJsonString(result));
+      Logger.i(MeasurementJsonConvertor.toJsonString(result));
       return result;   
     } else {
       throw new MeasurementError("Cannot resovle domain name");

--- a/android/src/com/google/wireless/speed/speedometer/measurements/HttpTask.java
+++ b/android/src/com/google/wireless/speed/speedometer/measurements/HttpTask.java
@@ -16,6 +16,7 @@
 package com.google.wireless.speed.speedometer.measurements;
 
 import com.google.wireless.speed.speedometer.Config;
+import com.google.wireless.speed.speedometer.Logger;
 import com.google.wireless.speed.speedometer.MeasurementDesc;
 import com.google.wireless.speed.speedometer.MeasurementError;
 import com.google.wireless.speed.speedometer.MeasurementResult;
@@ -264,20 +265,20 @@ public class HttpTask extends MeasurementTask {
         result.addResult("body", Base64.encodeToString(body.array(), Base64.DEFAULT));
       }
       
-      Log.i(SpeedometerApp.TAG, MeasurementJsonConvertor.toJsonString(result));
+      Logger.i(MeasurementJsonConvertor.toJsonString(result));
       return result;    
     } catch (MalformedURLException e) {
       errorMsg += e.getMessage() + "\n";
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
     } catch (IOException e) {
       errorMsg += e.getMessage() + "\n";
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
     } finally {
       if (inputStream != null) {
         try {
           inputStream.close();
         } catch (IOException e) {
-          Log.e(SpeedometerApp.TAG, "Fails to close the input stream from the HTTP response");
+          Logger.e("Fails to close the input stream from the HTTP response");
         }
       }
       if (httpClient != null) {

--- a/android/src/com/google/wireless/speed/speedometer/measurements/PingTask.java
+++ b/android/src/com/google/wireless/speed/speedometer/measurements/PingTask.java
@@ -16,6 +16,7 @@
 package com.google.wireless.speed.speedometer.measurements;
 
 import com.google.wireless.speed.speedometer.Config;
+import com.google.wireless.speed.speedometer.Logger;
 import com.google.wireless.speed.speedometer.MeasurementDesc;
 import com.google.wireless.speed.speedometer.MeasurementError;
 import com.google.wireless.speed.speedometer.MeasurementResult;
@@ -158,15 +159,15 @@ public class PingTask extends MeasurementTask {
     }
     
     try {
-      Log.i(SpeedometerApp.TAG, "running ping command");
+      Logger.i("running ping command");
       /* Prevents the phone from going to low-power mode where WiFi turns off */
       return executePingCmdTask();
     } catch (MeasurementError e) {
       try {
-        Log.i(SpeedometerApp.TAG, "running java ping");
+        Logger.i("running java ping");
         return executeJavaPingTask();
       } catch (MeasurementError ee) {
-        Log.i(SpeedometerApp.TAG, "running http ping");
+        Logger.i("running http ping");
         return executeHttpPingTask();
       }
     }
@@ -238,7 +239,7 @@ public class PingTask extends MeasurementTask {
         proc.destroy();
       }
     } catch (Exception e) { 
-      Log.w(SpeedometerApp.TAG, "Unable to kill ping process", e);
+      Logger.w("Unable to kill ping process", e);
     }
   }
   
@@ -265,7 +266,7 @@ public class PingTask extends MeasurementTask {
   
   // Runs when SystemState is IDLE
   private MeasurementResult executePingCmdTask() throws MeasurementError {
-    Log.i(SpeedometerApp.TAG, "Starting executePingCmdTask");
+    Logger.i("Starting executePingCmdTask");
     PingDesc pingTask = (PingDesc) this.measurementDesc;
     String errorMsg = "";
     MeasurementResult measurementResult = null;
@@ -276,7 +277,7 @@ public class PingTask extends MeasurementTask {
           Config.DEFAULT_INTERVAL_BETWEEN_ICMP_PACKET_SEC,
           "-s", pingTask.packetSizeByte, "-w", pingTask.pingTimeoutSec, "-c", 
           Config.PING_COUNT_PER_MEASUREMENT, targetIp);
-      Log.i(SpeedometerApp.TAG, "Running: " + command);
+      Logger.i("Running: " + command);
       pingProc = Runtime.getRuntime().exec(command);
       
       // Grab the output of the process that runs the ping command
@@ -316,7 +317,7 @@ public class PingTask extends MeasurementTask {
           packetLoss = 1 - ((double) packetsReceived / (double) packetsSent);
         }
         
-        Log.i(SpeedometerApp.TAG, line);
+        Logger.i(line);
       }
       // Use the output from the ping command to compute packet loss. If that's not
       // available, use an estimation.
@@ -324,18 +325,18 @@ public class PingTask extends MeasurementTask {
         packetLoss = 1 - ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
       }
       measurementResult = constructResult(rrts, packetLoss, packetsSent);
-      Log.i(SpeedometerApp.TAG, MeasurementJsonConvertor.toJsonString(measurementResult));
+      Logger.i(MeasurementJsonConvertor.toJsonString(measurementResult));
     } catch (IOException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";
     } catch (SecurityException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";
     } catch (NumberFormatException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";  
     } catch (InvalidParameterException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";
     } finally {
       // All associated streams with the process will be closed upon destroy()
@@ -343,7 +344,7 @@ public class PingTask extends MeasurementTask {
     }
     
     if (measurementResult == null) {
-      Log.e(SpeedometerApp.TAG, "Error running ping: " + errorMsg);
+      Logger.e("Error running ping: " + errorMsg);
       throw new MeasurementError(errorMsg);
     }
     return measurementResult;
@@ -375,20 +376,20 @@ public class PingTask extends MeasurementTask {
         this.progress = 100 * i / Config.PING_COUNT_PER_MEASUREMENT;
         broadcastProgressForUser(progress);
       }
-      Log.i(SpeedometerApp.TAG, "java ping succeeds");
+      Logger.i("java ping succeeds");
       double packetLoss = 1 - ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
       result = constructResult(rrts, packetLoss, Config.PING_COUNT_PER_MEASUREMENT);
     } catch (IllegalArgumentException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";
     } catch (IOException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";
     } 
     if (result != null) {
       return result;
     } else {
-      Log.i(SpeedometerApp.TAG, "java ping fails");
+      Logger.i("java ping fails");
       throw new MeasurementError(errorMsg);
     }
   }
@@ -428,20 +429,20 @@ public class PingTask extends MeasurementTask {
         this.progress = 100 * i / Config.PING_COUNT_PER_MEASUREMENT;
         broadcastProgressForUser(progress);
       }
-      Log.i(SpeedometerApp.TAG, "HTTP get ping succeeds");
+      Logger.i("HTTP get ping succeeds");
       double packetLoss = 1 - ((double) rrts.size() / (double) Config.PING_COUNT_PER_MEASUREMENT);
       result = constructResult(rrts, packetLoss, Config.PING_COUNT_PER_MEASUREMENT);
     } catch (MalformedURLException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";
     } catch (IOException e) {
-      Log.e(SpeedometerApp.TAG, e.getMessage());
+      Logger.e(e.getMessage());
       errorMsg += e.getMessage() + "\n";
     }
     if (result != null) {
       return result;
     } else {
-      Log.i(SpeedometerApp.TAG, "HTTP get ping fails");
+      Logger.i("HTTP get ping fails");
       throw new MeasurementError(errorMsg);
     }
   }

--- a/android/src/com/google/wireless/speed/speedometer/measurements/TracerouteTask.java
+++ b/android/src/com/google/wireless/speed/speedometer/measurements/TracerouteTask.java
@@ -16,6 +16,7 @@
 package com.google.wireless.speed.speedometer.measurements;
 
 import com.google.wireless.speed.speedometer.Config;
+import com.google.wireless.speed.speedometer.Logger;
 import com.google.wireless.speed.speedometer.MeasurementDesc;
 import com.google.wireless.speed.speedometer.MeasurementError;
 import com.google.wireless.speed.speedometer.MeasurementResult;
@@ -176,13 +177,13 @@ public class TracerouteTask extends MeasurementTask {
     boolean success = false;
     ArrayList<HopInfo> hopHosts = new ArrayList<HopInfo>();
     
-    Log.d(SpeedometerApp.TAG, "Starting traceroute on host " + task.target);
+    Logger.d("Starting traceroute on host " + task.target);
     
     
     try {
       hostIp = InetAddress.getByName(target).getHostAddress();
     } catch (UnknownHostException e) {
-      Log.e(SpeedometerApp.TAG, "Cannont resolve host " + target);
+      Logger.e("Cannont resolve host " + target);
       throw new MeasurementError("target " + target + " cannot be resolved");
     }
     MeasurementResult result = null;
@@ -214,7 +215,7 @@ public class TracerouteTask extends MeasurementTask {
           try {
             Thread.sleep((long) (task.pingIntervalSec * 1000));
           } catch (InterruptedException e) {
-            Log.i(SpeedometerApp.TAG, "Sleep interrupted between ping intervals");
+            Logger.i("Sleep interrupted between ping intervals");
           }
         }
         rtt = rtt / task.pingsPerHop;
@@ -226,8 +227,8 @@ public class TracerouteTask extends MeasurementTask {
         for (String ip : hostsAtThisDistance) {
           // If we have reached the final destination hostIp, print it out and clean up
           if (ip.compareTo(hostIp) == 0) {
-            Log.i(SpeedometerApp.TAG, ttl + ": " + hostIp);
-            Log.i(SpeedometerApp.TAG, " Finished! " + target + " reached in " + ttl + " hops");
+            Logger.i(ttl + ": " + hostIp);
+            Logger.i(" Finished! " + target + " reached in " + ttl + " hops");
 
             success = true;
             PhoneUtils phoneUtils = PhoneUtils.getPhoneUtils();
@@ -243,7 +244,7 @@ public class TracerouteTask extends MeasurementTask {
               }
               result.addResult("hop_" + i + "_rtt_ms", String.format("%.3f", hopInfo.rtt));
             }
-            Log.i(SpeedometerApp.TAG, MeasurementJsonConvertor.toJsonString(result));
+            Logger.i(MeasurementJsonConvertor.toJsonString(result));
             return result;
           } else {
             // Otherwise, we aggregate various hosts at a given hop distance for printout
@@ -252,13 +253,13 @@ public class TracerouteTask extends MeasurementTask {
         }
         // Remove the trailing separators
         progressStr.delete(progressStr.length() - 3, progressStr.length());
-        Log.i(SpeedometerApp.TAG, progressStr.toString());
+        Logger.i(progressStr.toString());
 
       } catch (SecurityException e) {
-        Log.e(SpeedometerApp.TAG, "Does not have the permission to run ping on this device");
+        Logger.e("Does not have the permission to run ping on this device");
       } catch (IOException e) {
-        Log.e(SpeedometerApp.TAG, "The ping program cannot be executed");
-        Log.e(SpeedometerApp.TAG, e.getMessage());
+        Logger.e("The ping program cannot be executed");
+        Logger.e(e.getMessage());
       } finally {
         cleanUp(pingProc);
       }
@@ -297,7 +298,7 @@ public class TracerouteTask extends MeasurementTask {
       String hostIp) throws IOException {
     String line = null;
     while ((line = br.readLine()) != null) {
-      Log.d(SpeedometerApp.TAG, line);
+      Logger.d(line);
       if (line.startsWith("From")) {
         String ip = getHostIp(line);
         if (ip != null && ip.compareTo(hostIp) != 0) {
@@ -346,7 +347,7 @@ public class TracerouteTask extends MeasurementTask {
             return false;
           }
         } catch (NumberFormatException e) {
-          Log.d(SpeedometerApp.TAG, ip + " is not a valid IP address");
+          Logger.d(ip + " is not a valid IP address");
           return false;
         }
       }

--- a/android/src/com/google/wireless/speed/speedometer/util/MeasurementJsonConvertor.java
+++ b/android/src/com/google/wireless/speed/speedometer/util/MeasurementJsonConvertor.java
@@ -25,6 +25,7 @@ import com.google.myjson.JsonParseException;
 import com.google.myjson.JsonPrimitive;
 import com.google.myjson.JsonSerializationContext;
 import com.google.myjson.JsonSerializer;
+import com.google.wireless.speed.speedometer.Logger;
 import com.google.wireless.speed.speedometer.MeasurementDesc;
 import com.google.wireless.speed.speedometer.MeasurementTask;
 import com.google.wireless.speed.speedometer.SpeedometerApp;
@@ -87,22 +88,22 @@ public class MeasurementJsonConvertor {
     } catch (JSONException e) {
       throw new IllegalArgumentException(e);
     } catch (SecurityException e) {
-      Log.w(SpeedometerApp.TAG, e.getMessage());
+      Logger.w(e.getMessage());
       throw new IllegalArgumentException(e);
     } catch (NoSuchMethodException e) {
-      Log.w(SpeedometerApp.TAG, e.getMessage());
+      Logger.w(e.getMessage());
       throw new IllegalArgumentException(e);
     } catch (IllegalArgumentException e) {
-      Log.w(SpeedometerApp.TAG, e.getMessage());
+      Logger.w(e.getMessage());
       throw new IllegalArgumentException(e);
     } catch (InstantiationException e) {
-      Log.w(SpeedometerApp.TAG, e.getMessage());
+      Logger.w(e.getMessage());
       throw new IllegalArgumentException(e);
     } catch (IllegalAccessException e) {
-      Log.w(SpeedometerApp.TAG, e.getMessage());
+      Logger.w(e.getMessage());
       throw new IllegalArgumentException(e);
     } catch (InvocationTargetException e) {
-      Log.w(SpeedometerApp.TAG, e.toString());
+      Logger.w(e.toString());
       throw new IllegalArgumentException(e);
     } 
   }
@@ -135,7 +136,7 @@ public class MeasurementJsonConvertor {
       } catch (NumberFormatException e) {
         throw new JsonParseException("Cannot convert time string: "  + json.toString());
       } catch (IllegalArgumentException e) {
-        Log.e(SpeedometerApp.TAG, "Cannot convert time string:" + json.toString());
+        Logger.e("Cannot convert time string:" + json.toString());
         throw new JsonParseException("Cannot convert time string: " + json.toString());
       } catch (ParseException e) {
         throw new JsonParseException("Cannot convert UTC time string: "  + json.toString());

--- a/android/src/com/google/wireless/speed/speedometer/util/PhoneUtils.java
+++ b/android/src/com/google/wireless/speed/speedometer/util/PhoneUtils.java
@@ -16,6 +16,7 @@ package com.google.wireless.speed.speedometer.util;
 
 import com.google.wireless.speed.speedometer.DeviceInfo;
 import com.google.wireless.speed.speedometer.DeviceProperty;
+import com.google.wireless.speed.speedometer.Logger;
 import com.google.wireless.speed.speedometer.R;
 import com.google.wireless.speed.speedometer.SpeedometerApp;
 
@@ -73,7 +74,6 @@ import java.util.List;
  */
 public class PhoneUtils {
 
-  private static final String DEBUG_TAG = "PhoneUtils";
   private static final String ANDROID_STRING = "Android";
   /** Returned by {@link #getNetwork()}. */
   public static final String NETWORK_WIFI = "Wifi";
@@ -221,9 +221,9 @@ public class PhoneUtils {
       // Some interesting info to look at in the logs
       NetworkInfo[] infos = connectivityManager.getAllNetworkInfo();
       for (NetworkInfo networkInfo : infos) {
-        Log.i(DEBUG_TAG, "Network: " + networkInfo);
+        Logger.i("Network: " + networkInfo);
       }
-      Log.i(DEBUG_TAG, "Phone type: " + getTelephonyPhoneType() +
+      Logger.i("Phone type: " + getTelephonyPhoneType() +
             ", Carrier: " + getTelephonyCarrierName());
     }
     assert connectivityManager != null;
@@ -363,10 +363,10 @@ public class PhoneUtils {
           LocationProvider provider = manager.getProvider(providerNameIter);
         } catch (SecurityException se) {
           // Not allowed to use this provider
-          Log.w(SpeedometerApp.TAG, "Unable to use provider " + providerNameIter);
+          Logger.w("Unable to use provider " + providerNameIter);
           continue;
         }
-        Log.i(DEBUG_TAG, providerNameIter + ": " +
+        Logger.i(providerNameIter + ": " +
               (manager.isProviderEnabled(providerNameIter) ? "enabled" : "disabled"));
       }
 
@@ -397,13 +397,12 @@ public class PhoneUtils {
       initLocation();
       Location location = locationManager.getLastKnownLocation(locationProviderName);
       if (location == null) {
-        Log.e(SpeedometerApp.TAG,
-              "Cannot obtain location from provider " + locationProviderName);
+        Logger.e("Cannot obtain location from provider " + locationProviderName);
         return new Location("unknown");
       }
       return location;
     } catch (IllegalArgumentException e) {
-      Log.e(SpeedometerApp.TAG, "Cannot obtain location", e);
+      Logger.e("Cannot obtain location", e);
       return new Location("unknown");
     }
   }
@@ -414,7 +413,7 @@ public class PhoneUtils {
       PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
       wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "tag");
     }
-    Log.d(SpeedometerApp.TAG, "PowerLock acquired");
+    Logger.d("PowerLock acquired");
     wakeLock.acquire();
   }
 
@@ -424,9 +423,9 @@ public class PhoneUtils {
     if (wakeLock != null) {
       try {
         wakeLock.release();
-        Log.i(SpeedometerApp.TAG, "PowerLock released");
+        Logger.i("PowerLock released");
       } catch (RuntimeException e) {
-        Log.e(SpeedometerApp.TAG, "Exception when releasing wakeup lock", e);
+        Logger.e("Exception when releasing wakeup lock", e);
       }
     }
   }
@@ -478,22 +477,22 @@ public class PhoneUtils {
 
     @Override
     public void onLocationChanged(Location location) {
-      Log.d(DEBUG_TAG, "location changed");
+      Logger.d("location changed");
     }
 
     @Override
     public void onProviderDisabled(String provider) {
-      Log.d(DEBUG_TAG, "provider disabled: " + provider);
+      Logger.d("provider disabled: " + provider);
     }
 
     @Override
     public void onProviderEnabled(String provider) {
-      Log.d(DEBUG_TAG, "provider enabled: " + provider);
+      Logger.d("provider enabled: " + provider);
     }
 
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
-      Log.d(DEBUG_TAG, "status changed: " + provider + "=" + status);
+      Logger.d("status changed: " + provider + "=" + status);
     }
   }
 
@@ -535,7 +534,7 @@ public class PhoneUtils {
       String packageName = context.getPackageName();
       return context.getPackageManager().getPackageInfo(packageName, 0).versionName;
     } catch (Exception e) {
-      Log.e(SpeedometerApp.TAG, "version name of the application cannot be found", e);
+      Logger.e("version name of the application cannot be found", e);
     }
     return "Unknown";
   }
@@ -579,7 +578,7 @@ public class PhoneUtils {
     this.isCharging = powerIntent.getIntExtra(BatteryManager.EXTRA_STATUS, 
         BatteryManager.BATTERY_STATUS_UNKNOWN) == BatteryManager.BATTERY_STATUS_CHARGING;
     
-    Log.i(SpeedometerApp.TAG, 
+    Logger.i(
         "Current power level is " + curBatteryLevel + " and isCharging = " + isCharging);
   }
   
@@ -689,7 +688,7 @@ public class PhoneUtils {
       InetAddress ipAddress = InetAddress.getByAddress(bytes);
       return ipAddress.getHostAddress();
     } catch (UnknownHostException e) {
-      Log.e(SpeedometerApp.TAG, "error when translating the wifi address to string");
+      Logger.e("error when translating the wifi address to string");
       return null;
     }
   }

--- a/android/src/com/google/wireless/speed/speedometer/util/Util.java
+++ b/android/src/com/google/wireless/speed/speedometer/util/Util.java
@@ -14,6 +14,7 @@
  */
 package com.google.wireless.speed.speedometer.util;
 
+import com.google.wireless.speed.speedometer.Logger;
 import com.google.wireless.speed.speedometer.R;
 import com.google.wireless.speed.speedometer.SpeedometerApp;
 
@@ -108,7 +109,7 @@ public class Util {
       return context.getString(R.string.user_agent);
 
     } catch (NameNotFoundException e) {
-      Log.e(SpeedometerApp.TAG, "Couldn't find package information in PackageManager", e);
+      Logger.e("Couldn't find package information in PackageManager", e);
       return context.getString(R.string.default_user_agent);
     }
   }


### PR DESCRIPTION
This pull request includes two commits:

1) The first fixes the logging code to go through a common "Logger" class so that all app logging can be easily disabled for release builds.

2) The second persists statistics on measurements being run in a preferences entry so the stats can be tracked across multiple runs of the app.

Please review the code and let me know if you suggest any changes.
